### PR TITLE
Use default solver in all tests (clarabel)

### DIFF
--- a/tests/random_networks_test.py
+++ b/tests/random_networks_test.py
@@ -173,7 +173,7 @@ def generate_r_ary_sample_network(
 #     upstream = conc_list_to_dict(network, concentrations)
 #     downstream = funmixer.forward_model(sample_network=network, upstream_concentrations=upstream)
 #     problem = funmixer.SampleNetworkUnmixer(sample_network=network, use_regularization=False)
-#     solution = problem.solve(downstream, solver="ecos")
+#     solution = problem.solve(downstream)
 
 #     # Check that the recovered upstream concentrations are within 0.1% of the true upstream concentrations using
 #     # the np.isclose function
@@ -218,7 +218,7 @@ def test_balanced_network(
     upstream = conc_list_to_dict(network, concentrations)
     downstream = funmixer.forward_model(sample_network=network, upstream_concentrations=upstream)
     problem = funmixer.SampleNetworkUnmixer(sample_network=network, use_regularization=False)
-    solution = problem.solve(downstream, solver="ecos")
+    solution = problem.solve(downstream)
 
     # Check that the recovered upstream concentrations are within 0.1% of the true upstream concentrations using
     # the np.isclose function
@@ -261,7 +261,7 @@ def test_rary_network(
     upstream = conc_list_to_dict(network, concentrations)
     downstream = funmixer.forward_model(sample_network=network, upstream_concentrations=upstream)
     problem = funmixer.SampleNetworkUnmixer(sample_network=network, use_regularization=False)
-    solution = problem.solve(downstream, solver="ecos")
+    solution = problem.solve(downstream)
 
     # Check that the recovered upstream concentrations are within 0.1% of the true upstream concentrations using
     # the np.isclose function

--- a/tests/runtime_benchmark.py
+++ b/tests/runtime_benchmark.py
@@ -164,7 +164,10 @@ def do_benchmark() -> None:
     start = time.time()
 
     print("Testing ECOS solver...")
-    ecos_bench = run_benchmark("ecos", network_sizes)
+    try:
+        ecos_bench: BenchmarkResults = run_benchmark("ecos", network_sizes)
+    except Exception as err:
+        print(f"Could not benchmark ECOS. Error: {err}")
 
     print("Testing GUROBI solver...")
     gurobi_bench: Optional[BenchmarkResults] = None

--- a/tests/synthetic_test.py
+++ b/tests/synthetic_test.py
@@ -49,7 +49,7 @@ def main() -> None:
     print("Building problem...")
     problem = funmixer.SampleNetworkUnmixer(sample_network, use_regularization=False)
     # Solve problem using synthetic downstream observations as input
-    solution = problem.solve(mixed_synth_down, solver="ecos", export_rates=input_export_rates)
+    solution = problem.solve(mixed_synth_down, export_rates=input_export_rates)
     # Generate recovered upstream concentration map
     print("Generating recovered upstream concentration map...")
     recovered_conc_map = funmixer.get_upstream_concentration_map(areas, solution.upstream_preds)


### PR DESCRIPTION
ECOS solver is not installed by default and only used for legacy reasons. This update changes unit tests to use the Clarabel solver (i.e., the default one) which doesn't need to be installed on top.