### PR TITLE
Implement first order non-conservative processes between nodes

### DIFF
--- a/funmixer/d8processing.py
+++ b/funmixer/d8processing.py
@@ -487,6 +487,8 @@ def get_sample_graph(
 
     # Build the sample site graph using the Cython functions for efficiency
     print("Building sample site graph...")
+    # Note: acc.dy comes from GDAL's GeoTransform()[5], which is typically negative for north-up rasters.
+    # We multiply by -1 here so that build_samplesite_graph receives a positive cell size in the y-direction.
     labels, graph = cf.build_samplesite_graph(
         acc.receivers, acc.baselevel_nodes, acc.arr.flatten(), sample_dict, acc.dx, acc.dy * -1
     )

--- a/funmixer/d8processing.py
+++ b/funmixer/d8processing.py
@@ -386,6 +386,16 @@ class D8Accumulator:
         miny = maxy + trsfm[5] * self.arr.shape[0]
         return [minx, maxx, miny, maxy]
 
+    @property
+    def dx(self) -> float:
+        """Get the cell size in the x direction"""
+        return self.ds.GetGeoTransform()[1]
+
+    @property
+    def dy(self) -> float:
+        """Get the cell size in the y direction"""
+        return self.ds.GetGeoTransform()[5]
+
     def _check_valid_node(self, node: int) -> None:
         """Checks if a node is valid"""
         if node < 0 or node >= self.arr.size:
@@ -477,7 +487,9 @@ def get_sample_graph(
 
     # Build the sample site graph using the Cython functions for efficiency
     print("Building sample site graph...")
-    labels, graph = cf.build_samplesite_graph(acc.receivers, acc.baselevel_nodes, sample_dict)
+    labels, graph = cf.build_samplesite_graph(
+        acc.receivers, acc.baselevel_nodes, sample_dict, acc.dx, acc.dy * -1
+    )
 
     # Convert the native (Cython) sample nodes to Python SampleNode objects
     sample_nodes = [SampleNode.from_native(node) for node in graph]
@@ -488,6 +500,6 @@ def get_sample_graph(
             continue
         sample_network.add_node(node.name, data=node)
         if sample_nodes[node.downstream_node].name != cf.ROOT_NODE_NAME:
-            sample_network.add_edge(node.name, sample_nodes[node.downstream_node].name)
+            sample_network.add_edge(node.name, sample_nodes[node.downstream_node].name, length=1)
 
     return sample_network, np.reshape(labels, acc.arr.shape)

--- a/funmixer/d8processing.py
+++ b/funmixer/d8processing.py
@@ -488,7 +488,7 @@ def get_sample_graph(
     # Build the sample site graph using the Cython functions for efficiency
     print("Building sample site graph...")
     labels, graph = cf.build_samplesite_graph(
-        acc.receivers, acc.baselevel_nodes, sample_dict, acc.dx, acc.dy * -1
+        acc.receivers, acc.baselevel_nodes, acc.arr.flatten(), sample_dict, acc.dx, acc.dy * -1
     )
 
     # Convert the native (Cython) sample nodes to Python SampleNode objects
@@ -500,6 +500,8 @@ def get_sample_graph(
             continue
         sample_network.add_node(node.name, data=node)
         if sample_nodes[node.downstream_node].name != cf.ROOT_NODE_NAME:
-            sample_network.add_edge(node.name, sample_nodes[node.downstream_node].name, length=1)
+            sample_network.add_edge(
+                node.name, sample_nodes[node.downstream_node].name, length=node.distance_downstream
+            )
 
     return sample_network, np.reshape(labels, acc.arr.shape)

--- a/funmixer/flow_acc_cfuncs.pyx
+++ b/funmixer/flow_acc_cfuncs.pyx
@@ -450,7 +450,7 @@ def build_samplesite_graph(
     if sample_parent_graph[0].total_upstream_area != len(receivers) * cell_area:
         raise ValueError(f"Total upstream area of root node ({sample_parent_graph[0].total_upstream_area}) does not match" + \
             f" the expected number from flow direction array ({len(receivers) * cell_area})!")
-        # Loop through the sample parent graph to assign labels
+    # Loop through the sample parent graph to assign labels
     for i in range(len(sample_parent_graph)):
         # Assign the label to the sample parent node
         sample_parent_graph[i].label = i  # Assign the label to the sample parent node

--- a/funmixer/flow_acc_cfuncs.pyx
+++ b/funmixer/flow_acc_cfuncs.pyx
@@ -59,7 +59,7 @@ cdef class NativeSampleNode:
         self.total_upstream_area = 0.
         self.label = -1  # Default label, will be set later
         self.d8_node = -1  # Default D8 node, will be set later
-        self.distance_to_parent = -1 # Default distance, will be set later
+        self.distance_to_parent = -1  # Default distance, will be set later
 
     @staticmethod
     def make_root_node():

--- a/funmixer/flow_acc_cfuncs.pyx
+++ b/funmixer/flow_acc_cfuncs.pyx
@@ -48,6 +48,8 @@ cdef class NativeSampleNode:
     cdef public cnp.float64_t area
     cdef public cnp.float64_t total_upstream_area
     cdef public cnp.int64_t label
+    cdef public cnp.int64_t d8_node
+    cdef public cnp.float64_t distance_to_parent
 
     def __cinit__(self):
         self.data = SampleData()
@@ -56,6 +58,8 @@ cdef class NativeSampleNode:
         self.area = 0.
         self.total_upstream_area = 0.
         self.label = -1  # Default label, will be set later
+        self.d8_node = -1  # Default D8 node, will be set later
+        self.distance_to_parent = -1 # Default distance, will be set later
 
     @staticmethod
     def make_root_node():
@@ -66,16 +70,19 @@ cdef class NativeSampleNode:
         temp = NativeSampleNode()
         temp.label = 0  # Root node label
         temp.data.name = ROOT_NODE_NAME
+        temp.d8_node = 0 # Set to (arbitrarily) be the top-left corner (which MUST be a sink anyway)
         return temp
 
     @staticmethod
-    def make_w_downstream_and_sample(cnp.int64_t downstream_node, SampleData sample_data):
+    def make_w_downstream_and_sample(cnp.int64_t downstream_node, SampleData sample_data, cnp.int64_t d8_node, cnp.float64_t distance_to_parent):
         """
         Factory method to create a node with a downstream neighbour and sample data.
         """
         cdef NativeSampleNode temp = NativeSampleNode()
         temp.downstream_node = downstream_node
         temp.data = sample_data
+        temp.d8_node = d8_node
+        temp.distance_to_parent = distance_to_parent
         return temp
 
 ### The following functions are related to the D8 flow direction array and its processing ###
@@ -316,12 +323,48 @@ def calculate_total_upstream_areas(list sample_graph):
         if deps[self.downstream_node] == 0:
             q.push(self.downstream_node)  # If no more dependencies, add to the queue
 
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
+def get_d8_dir_to_dist_dict(cnp.float64_t dx, cnp.float64_t dy):
+    """
+    Creates a dictionary mapping the directions of a D8 raster to absolute distance across a grid with dimensions dx and dy
+    """
+    cdef dict d8_dir_to_dist = {
+        0: 0, # Sink
+        1: dx, # Right
+        2: np.sqrt(dx**2 + dy**2), # Down-Right
+        4: dy, # Down
+        8: np.sqrt(dx**2 + dy**2), # Down-Left
+        16: dx, # Left
+        32: np.sqrt(dx**2 + dy**2), # Up-Left
+        64: dy, # Up
+        128: np.sqrt(dx**2 + dy**2), # Up-Right
+    }
+    return d8_dir_to_dist
+
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
+def count_distance_between(int up_node, int down_node, cnp.ndarray[cnp.int64_t, ndim=1] arr, cnp.int64_t[:] receivers, dict[int, float] dir_dist_dict):
+    """
+    Counts the distance between an upstream node and a downstream node, or next downstream sink node, in the flow network.
+    """
+    cdef double distance = 0
+    while up_node != down_node:
+        direction = arr[up_node]
+        distance += dir_dist_dict[direction]
+        up_node = receivers[up_node]
+        if direction == 0:
+            if up_node != down_node:
+                print("Warning: reached a sink node before the downstream node!")
+            break
+    return distance
 
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
 def build_samplesite_graph(
     cnp.int64_t[:] receivers, 
-    cnp.ndarray[cnp.int64_t, ndim=1] baselevel_nodes, 
+    cnp.ndarray[cnp.int64_t, ndim=1] baselevel_nodes,
+    cnp.ndarray[cnp.int64_t, ndim=1] arr,
     dict[int, dict[str,object]] sample_dict,
     cnp.float64_t dx,
     cnp.float64_t dy,
@@ -334,6 +377,7 @@ def build_samplesite_graph(
         receivers: The receiver array (i.e., receiver[i] is the ID
         of the node that receives the flow from the i'th node).
         baselevel_nodes: The baselevel nodes to start from (i.e., sink-nodes).
+        arr: The D8 flow-direction array (flattened).
         sample_dict: A dictionary mapping sample site nodes to their metadata,
         where keys are node indices and metadata is a dictionary with keys "name", "x", and "y".
         dx: The cell size in the x direction (float).
@@ -352,6 +396,8 @@ def build_samplesite_graph(
     cdef SampleData data
     # Create a variable to contain the cell area which is product of dx and dy
     cdef double cell_area = dx * dy
+    # Create a dictionary to map D8 directions to their distances to next node
+    cdef dict dir_to_dist = get_d8_dir_to_dist_dict(dx=dx, dy=dy)
     # Initialize the sample parent graph as a list of NativeSampleNode
     cdef list sample_parent_graph = []
     # Initialize a queue for breadth-first search
@@ -369,6 +415,7 @@ def build_samplesite_graph(
         node = q.front()
         q.pop()
 
+
         # Check if the node is a sample site
         if node in sample_dict:
             # Extract sample data from the sample_dict
@@ -377,9 +424,15 @@ def build_samplesite_graph(
             my_new_label = len(sample_parent_graph)
             my_current_label = labels[node]
             parent = sample_parent_graph[my_current_label]
+
+            print("-"*40)
+            print(f"Found upstream node {node}, corresponding sample site is {sample_dict[node]['name']}")
+            print(f"{sample_dict[node]['name']} has a parent sample site {parent.data.name}, at D8 node {parent.d8_node} (equal to: {sample_dict[parent.d8_node]['name'] if parent.d8_node in sample_dict else 'N/A'})")
+            distance = count_distance_between(up_node = node, down_node = parent.d8_node, arr = arr, receivers = receivers, dir_dist_dict = dir_to_dist)
+            print(f"Distance between {sample_dict[node]['name']} and {parent.data.name} is {distance}")
             parent.upstream_nodes.append(data.name)  # Add the sample site name to the parent node's upstream nodes
             sample_parent_graph.append(
-                NativeSampleNode.make_w_downstream_and_sample(my_current_label, data)
+                NativeSampleNode.make_w_downstream_and_sample(my_current_label, data, node, distance)
             )  # Create a new sample node with the sample data
             # Update the label for the sample site node
             labels[node] = my_new_label  # Assign the new label to the sample site node

--- a/funmixer/flow_acc_cfuncs.pyx
+++ b/funmixer/flow_acc_cfuncs.pyx
@@ -354,8 +354,8 @@ def count_distance_between(int up_node, int down_node, cnp.ndarray[cnp.int64_t, 
         distance += dir_dist_dict[direction]
         up_node = receivers[up_node]
         if direction == 0:
-            if up_node != down_node:
-                print("Warning: reached a sink node before the downstream node!")
+            # if up_node != down_node:
+            #     print("Warning: reached a sink node before the downstream node!")
             break
     return distance
 
@@ -425,11 +425,7 @@ def build_samplesite_graph(
             my_current_label = labels[node]
             parent = sample_parent_graph[my_current_label]
 
-            print("-"*40)
-            print(f"Found upstream node {node}, corresponding sample site is {sample_dict[node]['name']}")
-            print(f"{sample_dict[node]['name']} has a parent sample site {parent.data.name}, at D8 node {parent.d8_node} (equal to: {sample_dict[parent.d8_node]['name'] if parent.d8_node in sample_dict else 'N/A'})")
             distance = count_distance_between(up_node = node, down_node = parent.d8_node, arr = arr, receivers = receivers, dir_dist_dict = dir_to_dist)
-            print(f"Distance between {sample_dict[node]['name']} and {parent.data.name} is {distance}")
             parent.upstream_nodes.append(data.name)  # Add the sample site name to the parent node's upstream nodes
             sample_parent_graph.append(
                 NativeSampleNode.make_w_downstream_and_sample(my_current_label, data, node, distance)

--- a/funmixer/flow_acc_cfuncs.pyx
+++ b/funmixer/flow_acc_cfuncs.pyx
@@ -45,16 +45,16 @@ cdef class NativeSampleNode:
     cdef public SampleData data
     cdef public cnp.int64_t downstream_node
     cdef public list upstream_nodes
-    cdef public cnp.int64_t area
-    cdef public cnp.int64_t total_upstream_area
+    cdef public cnp.float64_t area
+    cdef public cnp.float64_t total_upstream_area
     cdef public cnp.int64_t label
 
     def __cinit__(self):
         self.data = SampleData()
         self.downstream_node = NO_DOWNSTREAM_NEIGHBOUR
         self.upstream_nodes = []
-        self.area = 0
-        self.total_upstream_area = 0
+        self.area = 0.
+        self.total_upstream_area = 0.
         self.label = -1  # Default label, will be set later
 
     @staticmethod
@@ -323,6 +323,8 @@ def build_samplesite_graph(
     cnp.int64_t[:] receivers, 
     cnp.ndarray[cnp.int64_t, ndim=1] baselevel_nodes, 
     dict[int, dict[str,object]] sample_dict,
+    cnp.float64_t dx,
+    cnp.float64_t dy,
     ):
     """
     Creates a map of subbasins, where each subbasin is assigned a unique ID from 0 (baselevel) to n (number of subbasins). 
@@ -334,6 +336,8 @@ def build_samplesite_graph(
         baselevel_nodes: The baselevel nodes to start from (i.e., sink-nodes).
         sample_dict: A dictionary mapping sample site nodes to their metadata,
         where keys are node indices and metadata is a dictionary with keys "name", "x", and "y".
+        dx: The cell size in the x direction (float).
+        dy: The cell size in the y direction (float).
     """
     # Initialize variables
     cdef int nr = len(receivers)
@@ -346,6 +350,8 @@ def build_samplesite_graph(
     cdef cnp.int64_t my_current_label
     cdef NativeSampleNode parent
     cdef SampleData data
+    # Create a variable to contain the cell area which is product of dx and dy
+    cdef double cell_area = dx * dy
     # Initialize the sample parent graph as a list of NativeSampleNode
     cdef list sample_parent_graph = []
     # Initialize a queue for breadth-first search
@@ -380,7 +386,7 @@ def build_samplesite_graph(
 
         # Get the label of the current node
         my_label = labels[node]
-        sample_parent_graph[my_label].area += 1  # Increment the area of the sample node
+        sample_parent_graph[my_label].area += cell_area  # Increment the area of the sample node by the cell area
 
         # Loop through the donors of the node and add them to the queue
         for n in range(delta[node], delta[node + 1]):
@@ -392,10 +398,10 @@ def build_samplesite_graph(
     # Calculate the total upstream areas for each sample node having built the sample parent graph
     calculate_total_upstream_areas(sample_parent_graph)
     # Check that the total upstream area of the root node is equal to the number of pixels
-    if sample_parent_graph[0].total_upstream_area != nr:
-        raise ValueError("Total upstream area of root node does not match the number of pixels in the flow direction array!")
-
-    # Loop through the sample parent graph to assign labels
+    if sample_parent_graph[0].total_upstream_area != len(receivers) * cell_area:
+        raise ValueError(f"Total upstream area of root node ({sample_parent_graph[0].total_upstream_area}) does not match" + \
+            f" the expected number from flow direction array ({len(receivers) * cell_area})!")
+        # Loop through the sample parent graph to assign labels
     for i in range(len(sample_parent_graph)):
         # Assign the label to the sample parent node
         sample_parent_graph[i].label = i  # Assign the label to the sample parent node

--- a/funmixer/network_unmixer.py
+++ b/funmixer/network_unmixer.py
@@ -41,6 +41,7 @@ ELEMENT_LIST: Final[List[str]] = ["H", "He", "Li", "Be", "B", "C", "N", "O", "F"
 
 ElementData = Dict[str, float]
 ExportRateData = Dict[str, float]
+RateConstantData = Dict[str, float]
 
 T = TypeVar("T")
 
@@ -74,6 +75,7 @@ class SampleNode:
         rltv_area: The relative area of the sample node (i.e., area divided by total_upstream_area)
         total_flux: The total flux of material leaving the sample node (i.e., sum of all fluxes upstream of site inclusive)
         my_export_rate: The rate at which sub-basin is producing material (e.g., runoff, erosion rate etc...), defaults to 1
+        my_rate_constant: The 1st order rate constant of the tracer from sub-basin to next sub-basin, defaults to 0 (i.e., conservative)
     """
 
     name: str
@@ -94,6 +96,7 @@ class SampleNode:
     rltv_area: float = -np.inf  # Obviously bad value
     total_flux: Optional[cp.Expression] = None
     my_export_rate: cp.Parameter = field(default_factory=lambda: cp.Parameter(pos=True))
+    my_rate_constant: float = 0.0
 
     @classmethod
     def from_native(cls, n: cf.NativeSampleNode) -> "SampleNode":
@@ -284,6 +287,7 @@ class SampleNetworkUnmixer:
         self,
         sample_network: nx.DiGraph,
         use_regularization: bool = True,
+        rate_constants: Optional[RateConstantData] = None,
     ) -> None:
         """
         Initialize the SampleNetworkUnmixer class.
@@ -291,17 +295,20 @@ class SampleNetworkUnmixer:
         Args:
             sample_network (nx.DiGraph): The sample network.
             use_regularization (bool): Flag indicating whether to use regularization.
+            rate_constants (Optional[RateConstantData]): The rate-constants for each reach/edge downstream of the site for the element. If not provided these are all set to 0 (i.e., conservative behaviour).
         """
 
         self.sample_network = sample_network
         self._site_to_observation: Dict[str, ReciprocalParameter] = {}
         self._site_to_export_rate: Dict[str, cp.Parameter] = {}
+        self._site_to_rate_constant: Dict[str, float] = {}
         self._site_to_total_flux: Dict[str, ReciprocalParameter] = {}
         self._primary_terms: List[cp.Expression] = []
         self._regularizer_terms: List[cp.Expression] = []
         self._constraints: List[cp.Constraint] = []
         self._regularizer_strength = cp.Parameter(nonneg=True)
         self._problem: Optional[cp.Problem] = None
+        self._set_rate_constants(rate_constants)
         self._build_primary_terms()
         if use_regularization:
             self._build_regularizer_terms()
@@ -347,7 +354,7 @@ class SampleNetworkUnmixer:
             # Value is set at runtime
             my_data.my_export_rate = cp.Parameter(pos=True)
             self._site_to_export_rate[my_data.name] = my_data.my_export_rate
-
+            my_data.my_rate_constant = self._site_to_rate_constant[my_data.name]
             # Area weighted total contribution of material from this node
             my_data.my_flux = my_data.my_export_rate * my_data.rltv_area
 
@@ -392,13 +399,12 @@ class SampleNetworkUnmixer:
             if (ds := nx_get_downstream_data(self.sample_network, sample_name)) is not None:
                 # Get the distance between the nodes
                 ds_downstream = self.sample_network[sample_name][ds.name]["length"]
-                k = 0.0
+                # Calculate the first order rate weighting for non conservative processes (assumed decay)
+                first_order_rate_weighting = np.exp(-my_data.my_rate_constant * ds_downstream)
                 # Add our flux to downstream node's
                 ds.my_total_flux += my_data.my_total_flux
-                # Add our *tracer* flux to the downstream node's # weighted by exponential decay
-                ds.my_total_tracer_flux += my_data.my_total_tracer_flux * np.exp(
-                    -k * ds_downstream
-                )  # First order rate equation for decay
+                # Add our *tracer* flux to the downstream node's weighted by 1st order rate equation
+                ds.my_total_tracer_flux += my_data.my_total_tracer_flux * first_order_rate_weighting
 
     def _build_regularizer_terms(self) -> None:
         """
@@ -474,6 +480,30 @@ class SampleNetworkUnmixer:
         for x in self._site_to_export_rate.values():
             assert x.value is not None
 
+    def _set_rate_constants(self, rate_constants: Optional[RateConstantData] = None) -> None:
+        """
+        Set the rate constants according to input rate constants. The NetworkUnmixer must be reinitialised to change these.
+        """
+
+        # Populate dictionary with the default rate constants initially
+        for data in nx_values(self.sample_network):
+            self._site_to_rate_constant[data.name] = data.my_rate_constant
+
+        # If rate_constants are provided, assign each one to a site, making sure that the site exists
+        if rate_constants:
+            for site, value in rate_constants.items():
+                assert site in self._site_to_rate_constant
+                self._site_to_rate_constant[site] = value
+
+        # Else, check that rate constant is set to default value of 0 (i.e., conservative behaviour)
+        else:
+            for x in self._site_to_rate_constant.values():
+                assert x == 0.0
+
+        # Ensure that all sites in the problem have a rate constant assigned
+        for x in self._site_to_rate_constant.values():
+            assert x is not None
+
     def _set_total_flux_parameters(self) -> None:
         """
         Reset and set the total flux parameters according to total fluxes calculated in network.
@@ -506,7 +536,7 @@ class SampleNetworkUnmixer:
 
         Args:
             observation_data: The observed data for each element.
-            export_rates: The export rates for each element. If not provided these are all set to 1.
+            export_rates: The export rates for each sub-catchment. If not provided these are all set to 1 (i.e., homogenous erosion/runoff).
             regularization_strength: The strength of the regularization term
             solver: The solver to use for solving the optimization problem (default is clarabel)
 
@@ -579,6 +609,7 @@ class SampleNetworkUnmixer:
         relative_error: float,
         num_repeats: int,
         export_rates: Optional[ExportRateData] = None,
+        rate_constants: Optional[RateConstantData] = None,
         regularization_strength: Optional[float] = None,
         solver: str = "clarabel",
     ) -> Tuple[DefaultDict[str, List[float]], Dict[str, List[float]]]:
@@ -594,6 +625,7 @@ class SampleNetworkUnmixer:
             relative_error: The *relative* error as a percentage to use for resampling the observation data.
             num_repeats: The number of times to repeat the Monte Carlo simulation.
             export_rates: The export rates for each element. If not provided these are all set to 1.
+            rate_constants: The rate-constants for each reach/edge downstream of the site for the element. If not provided these are all set to 0 (i.e., conservative behaviour).
             regularization_strength: The strength of the regularization term (default: None).
             solver: The solver to use for solving the optimization problem (default: "clarabel").
 
@@ -627,6 +659,7 @@ class SampleNetworkUnmixer:
                 solver=solver,
                 regularization_strength=regularization_strength,
                 export_rates=export_rates,
+                rate_constants=rate_constants,
             )  # Solve problem
             for sample_name, v in solution.downstream_preds.items():
                 predictions_down_mc[sample_name].append(v)
@@ -727,12 +760,14 @@ def forward_model(
     sample_network: nx.DiGraph,
     upstream_concentrations: ElementData,
     export_rates: Optional[ExportRateData] = None,
+    rate_constants: Optional[RateConstantData] = None,
 ) -> ElementData:
     """Predicts the downstream concentration at sample sites using a forward model.
     Args:
         sample_network: A sample_network of localities (see `get_sample_graphs`)
         upstream_concentrations: Dictionary of upstream concentrations at sample sites
         export_rates: Dictionary of export rates for each sub-catchment. Defaults to equal export rate in each sub-catchment.
+        rate_constants: Dictionary of rate constants for each sub-catchment. Defaults to zero (i.e., conservative behaviour).
     Returns:
         mixed_downstream_pred: Dictionary containing predicted downstream mixed concentration at each sample sites
     """
@@ -748,6 +783,10 @@ def forward_model(
         # pyre-fixme[8]: Attribute has type `Parameter`; used as `float`.
         my_data.my_export_rate = export_rates[sample_name] if export_rates else 1.0
 
+        # If provided, set rate constants from user input
+        # else default to zero (i.e., conservative behaviour)
+        my_data.my_rate_constant = rate_constants[sample_name] if rate_constants else 0.0
+
         # pyre-fixme[8]: Attribute has type `Optional[Expression]`; used as `float`.
         my_data.my_tracer_value = upstream_concentrations[sample_name]
         # area weighted total contribution of material from this node
@@ -758,6 +797,7 @@ def forward_model(
         # pyre-fixme[58]: `*` is not supported for operand types `Union[None,
         #  cp.expressions.expression.Expression, float]` and
         #  `Optional[cp.expressions.expression.Expression]`.
+
         my_data.my_tracer_flux = my_data.my_flux * my_data.my_tracer_value
         # Add the *tracer* flux I generate to the total flux of *tracer* passing through me
         my_data.my_total_tracer_flux += my_data.my_tracer_flux
@@ -767,8 +807,10 @@ def forward_model(
         if (ds := nx_get_downstream_data(sample_network, sample_name)) is not None:
             # Add our flux to downstream node's
             ds.my_total_flux += my_data.my_total_flux
+            downstream_distance = sample_network[sample_name][ds.name]["length"]
+            first_order_rate_weighting = np.exp(-my_data.my_rate_constant * downstream_distance)
             # Add our *tracer* flux to the downstream node's
-            ds.my_total_tracer_flux += my_data.my_total_tracer_flux
+            ds.my_total_tracer_flux += my_data.my_total_tracer_flux * first_order_rate_weighting
 
     return mixed_downstream_pred
 
@@ -778,6 +820,7 @@ def mix_downstream(
     areas: Dict[str, npt.NDArray[np.float64]],
     concentration_map: npt.NDArray[np.float64],
     export_rates: Optional[ExportRateData] = None,
+    rate_constants: Optional[RateConstantData] = None,
 ) -> Tuple[ElementData, ElementData]:
     """Mixes a given concentration map along drainage, predicting the downstream concentration at sample sites
     Args:
@@ -786,6 +829,7 @@ def mix_downstream(
         concentration_map: A 2D map of concentrations which is to be mixed along drainage. Must have same dimensions
         as base flow-direction map/DEM
         export_rates: Dictionary of export rates for each sub-catchment. Defaults to equal export rate in each sub-catchment.
+        rate_constants: Dictionary of rate constants for each sub-catchment. Defaults to zero (i.e., conservative behaviour).
     Returns:
         mixed_downstream_pred: Dictionary containing predicted downstream mixed concentration at each sample sites
         mixed_upstream_pred: Dictionary containing the average concentration of `concentration_map` in each sub-basin
@@ -795,7 +839,9 @@ def mix_downstream(
         sample_name: float(np.mean(concentration_map[area])) for sample_name, area in areas.items()
     }
     # Predict downstream concentration at each sample site
-    mixed_downstream_pred = forward_model(sample_network, mixed_upstream_pred, export_rates)
+    mixed_downstream_pred = forward_model(
+        sample_network, mixed_upstream_pred, export_rates, rate_constants
+    )
     return mixed_downstream_pred, mixed_upstream_pred
 
 
@@ -823,6 +869,7 @@ def plot_sweep_of_regularizer_strength(
     max_: float,
     trial_num: int,
     export_rates: Optional[ExportRateData] = None,
+    rate_constants: Optional[RateConstantData] = None,
 ) -> None:
     """
     Plot a sweep of regularization strengths and their impact on roughness and data misfit.
@@ -833,7 +880,8 @@ def plot_sweep_of_regularizer_strength(
         min_: The minimum exponent for the logspace range of regularization strengths to try.
         max_: The maximum exponent for the logspace range of regularization strengths to try.
         trial_num: The number of regularization strengths to try within the specified range.
-        export_rates: Dictionary of export rates for each sub-catchment. Defaults to equal export rate in each sub-catchment
+        export_rates: Dictionary of export rates for each sub-catchment. Defaults to equal export rate in each sub-catchment.
+        rate_constants: Dictionary of rate constants for each sub-catchment. Defaults to zero (i.e., conservative behaviour).
 
     Note:
         The function performs a sweep of regularization strengths within a specified logspace range and plots their
@@ -856,6 +904,7 @@ def plot_sweep_of_regularizer_strength(
             element_data,
             regularization_strength=val,
             export_rates=export_rates,
+            rate_constants=rate_constants,
         )
         roughness = sample_network.get_roughness()
         misfit = sample_network.get_misfit()

--- a/funmixer/network_unmixer.py
+++ b/funmixer/network_unmixer.py
@@ -60,6 +60,7 @@ class SampleNode:
         x: The x-coordinate of the sample location.
         y: The y-coordinate of the sample location.
         downstream_node: The name of the downstream neighbor.
+        distance_downstream: The distance (along flow paths) to downstream neighbor.
         upstream_nodes: The name of the upstream neighbors.
         area: The area of the sub-basin defined by node (in the units of the D8 raster).
         total_upstream_area: The total area of sub-basin and all upstream neighbors (in the units of the D8 raster).
@@ -82,8 +83,9 @@ class SampleNode:
     upstream_nodes: List[str]
     area: float
     total_upstream_area: int
-    # Properties added dynamically by Python
+    distance_downstream: float
     label: int
+    # Properties added dynamically by Python
     my_flux: Optional[Union[float, cp.Expression]] = None
     my_total_flux: Union[float, cp.Expression] = 0.0
     my_total_tracer_flux: Union[float, cp.Expression] = 0.0
@@ -104,6 +106,7 @@ class SampleNode:
             area=n.area,
             total_upstream_area=n.total_upstream_area,
             label=n.label,
+            distance_downstream=n.distance_to_parent,
         )
 
 

--- a/funmixer/network_unmixer.py
+++ b/funmixer/network_unmixer.py
@@ -53,7 +53,26 @@ def not_none(x: Optional[T]) -> T:
 @dataclass
 class SampleNode:
     """
-    A class to represent a sample node in a Sample Network.
+    A class to represent a nested sample site & sub-basin in a drainage network.
+
+    Attributes (derived from D8 raster)
+        name: The name of the sample node.
+        x: The x-coordinate of the sample location.
+        y: The y-coordinate of the sample location.
+        downstream_node: The name of the downstream neighbor.
+        upstream_nodes: The name of the upstream neighbors.
+        area: The area of the sub-basin defined by node (in the units of the D8 raster).
+        total_upstream_area: The total area of sub-basin and all upstream neighbors (in the units of the D8 raster).
+
+    Attributes (set dynamically by Python)
+        label: The label of the sample node (an integer corresponding to its position in the network).
+        my_flux: The flux of material leaving the sample node (i.e., area multiplied by export rate [if set])
+        my_total_flux: The total flux of material leaving the sample node (i.e., total_upstream_area multiplied by export rate [if set])
+        my_tracer_flux: The flux of tracer leaving the sample node
+        my_tracer_value: The value (i.e., observed concentration) of tracer at the sample site
+        rltv_area: The relative area of the sample node (i.e., area divided by total_upstream_area)
+        total_flux: The total flux of material leaving the sample node (i.e., sum of all fluxes upstream of site inclusive)
+        my_export_rate: The rate at which sub-basin is producing material (e.g., runoff, erosion rate etc...), defaults to 1
     """
 
     name: str
@@ -368,10 +387,15 @@ class SampleNetworkUnmixer:
             self._primary_terms.append(misfit)
 
             if (ds := nx_get_downstream_data(self.sample_network, sample_name)) is not None:
+                # # Get the distance between the nodes
+                # ds_downstream = self.sample_network[sample_name][ds.name]["length"]
                 # Add our flux to downstream node's
                 ds.my_total_flux += my_data.my_total_flux
                 # Add our *tracer* flux to the downstream node's
                 ds.my_total_tracer_flux += my_data.my_total_tracer_flux
+
+                # # Add our *tracer* flux to the downstream node's weighted by exponential decay
+                # ds.my_total_tracer_flux += my_data.my_total_tracer_flux * cp.exp(-k*ds_downstream)
 
     def _build_regularizer_terms(self) -> None:
         """

--- a/funmixer/network_unmixer.py
+++ b/funmixer/network_unmixer.py
@@ -84,7 +84,7 @@ class SampleNode:
     downstream_node: Optional[str]
     upstream_nodes: List[str]
     area: float
-    total_upstream_area: int
+    total_upstream_area: float
     distance_downstream: float
     label: int
     # Properties added dynamically by Python

--- a/funmixer/network_unmixer.py
+++ b/funmixer/network_unmixer.py
@@ -609,7 +609,6 @@ class SampleNetworkUnmixer:
         relative_error: float,
         num_repeats: int,
         export_rates: Optional[ExportRateData] = None,
-        rate_constants: Optional[RateConstantData] = None,
         regularization_strength: Optional[float] = None,
         solver: str = "clarabel",
     ) -> Tuple[DefaultDict[str, List[float]], Dict[str, List[float]]]:
@@ -659,7 +658,6 @@ class SampleNetworkUnmixer:
                 solver=solver,
                 regularization_strength=regularization_strength,
                 export_rates=export_rates,
-                rate_constants=rate_constants,
             )  # Solve problem
             for sample_name, v in solution.downstream_preds.items():
                 predictions_down_mc[sample_name].append(v)

--- a/funmixer/network_unmixer.py
+++ b/funmixer/network_unmixer.py
@@ -392,7 +392,7 @@ class SampleNetworkUnmixer:
             if (ds := nx_get_downstream_data(self.sample_network, sample_name)) is not None:
                 # Get the distance between the nodes
                 ds_downstream = self.sample_network[sample_name][ds.name]["length"]
-                k = 0.0001
+                k = 0.0
                 # Add our flux to downstream node's
                 ds.my_total_flux += my_data.my_total_flux
                 # Add our *tracer* flux to the downstream node's # weighted by exponential decay

--- a/funmixer/network_unmixer.py
+++ b/funmixer/network_unmixer.py
@@ -390,15 +390,15 @@ class SampleNetworkUnmixer:
             self._primary_terms.append(misfit)
 
             if (ds := nx_get_downstream_data(self.sample_network, sample_name)) is not None:
-                # # Get the distance between the nodes
-                # ds_downstream = self.sample_network[sample_name][ds.name]["length"]
+                # Get the distance between the nodes
+                ds_downstream = self.sample_network[sample_name][ds.name]["length"]
+                k = 0.0001
                 # Add our flux to downstream node's
                 ds.my_total_flux += my_data.my_total_flux
-                # Add our *tracer* flux to the downstream node's
-                ds.my_total_tracer_flux += my_data.my_total_tracer_flux
-
-                # # Add our *tracer* flux to the downstream node's weighted by exponential decay
-                # ds.my_total_tracer_flux += my_data.my_total_tracer_flux * cp.exp(-k*ds_downstream)
+                # Add our *tracer* flux to the downstream node's # weighted by exponential decay
+                ds.my_total_tracer_flux += my_data.my_total_tracer_flux * np.exp(
+                    -k * ds_downstream
+                )  # First order rate equation for decay
 
     def _build_regularizer_terms(self) -> None:
         """

--- a/funmixer/network_unmixer.py
+++ b/funmixer/network_unmixer.py
@@ -56,7 +56,7 @@ class SampleNode:
     """
     A class to represent a nested sample site & sub-basin in a drainage network.
 
-    Attributes (derived from D8 raster)
+    Attributes
         name: The name of the sample node.
         x: The x-coordinate of the sample location.
         y: The y-coordinate of the sample location.
@@ -65,8 +65,6 @@ class SampleNode:
         upstream_nodes: The name of the upstream neighbors.
         area: The area of the sub-basin defined by node (in the units of the D8 raster).
         total_upstream_area: The total area of sub-basin and all upstream neighbors (in the units of the D8 raster).
-
-    Attributes (set dynamically by Python)
         label: The label of the sample node (an integer corresponding to its position in the network).
         my_flux: The flux of material leaving the sample node (i.e., area multiplied by export rate [if set])
         my_total_flux: The total flux of material leaving the sample node (i.e., total_upstream_area multiplied by export rate [if set])
@@ -87,7 +85,6 @@ class SampleNode:
     total_upstream_area: int
     distance_downstream: float
     label: int
-    # Properties added dynamically by Python
     my_flux: Optional[Union[float, cp.Expression]] = None
     my_total_flux: Union[float, cp.Expression] = 0.0
     my_total_tracer_flux: Union[float, cp.Expression] = 0.0

--- a/tests/random_networks_test.py
+++ b/tests/random_networks_test.py
@@ -87,6 +87,7 @@ def generate_random_sample_network(
             total_upstream_area=0,
             label=0,
             upstream_nodes=[],
+            distance_downstream=1.0,
         )
         i += 1
     return G
@@ -113,6 +114,7 @@ def generate_balanced_sample_network(
             total_upstream_area=0,
             label=0,
             upstream_nodes=[],
+            distance_downstream=1.0,
         )
         i += 1
     return G
@@ -140,6 +142,7 @@ def generate_r_ary_sample_network(
             total_upstream_area=0,
             label=0,
             upstream_nodes=[],
+            distance_downstream=1.0,
         )
         i += 1
     return G

--- a/tests/random_networks_test.py
+++ b/tests/random_networks_test.py
@@ -19,11 +19,15 @@ def max_height_of_balanced_tree(N: int, branching_factor: int) -> int:
 
 # Set the range to explore upstream concentration values over
 MINIMUM_CONC = 1
-MAXIMUM_CONC = 1e2
+MAXIMUM_CONC = 1e2  # Largest sub-basin source concentration is 100x larger than the smallest
 
 # Set the range to explore sub-basin area values over
 MINIMUM_AREA = 1
-MAXIMUM_AREA = 1e2
+MAXIMUM_AREA = 1e2  # Largest sub-basin is 100x larger than the smallest
+
+# Set the range of rate parameters to explore ranges over
+MIN_RATE_PARAMETER = 0  # When rate parameter = 0 results in fully conservative behaviour
+MAX_RATE_PARAMETER = 3  # When rate parameter = 3 results in 95% reduction of each tracer 'decaying' between nodes (~fully non-conservative)
 
 # Maximum number of nodes in a random network
 MAXIMUM_NUMBER_OF_NODES = 100
@@ -74,6 +78,9 @@ def generate_random_sample_network(
     G = nx.random_tree(N, create_using=nx.DiGraph, seed=seed)
     # Flip the tree upside down
     G = nx.reverse(G)
+    # Set the "length" of all edges to 1
+    for u, v in G.edges:
+        G[u][v]["length"] = 1.0
     # Loop through nodes and add SampleNode objects to ["data"] property
     i = 0
     for node in G.nodes:
@@ -101,6 +108,9 @@ def generate_balanced_sample_network(
     """
     G = nx.balanced_tree(r=branching_factor, h=height, create_using=nx.DiGraph)
     G = G.reverse()
+    # Set the "length" of all edges to 1
+    for u, v in G.edges:
+        G[u][v]["length"] = 1.0
     # Loop through nodes and add SampleNode objects to ["data"] property
     i = 0
     for node in G.nodes:
@@ -129,6 +139,9 @@ def generate_r_ary_sample_network(
     # Check that areas and N are compatible
     G = nx.full_rary_tree(r=branching_factor, n=N, create_using=nx.DiGraph)
     G = G.reverse()
+    # Set the "length" of all edges to 1
+    for u, v in G.edges:
+        G[u][v]["length"] = 1.0
     # Loop through nodes and add SampleNode objects to ["data"] property
     i = 0
     for node in G.nodes:
@@ -190,6 +203,8 @@ def generate_r_ary_sample_network(
 @given(
     branching_factor=st.integers(min_value=1, max_value=MAXIMUM_BRANCHING_FACTOR),
     height=st.integers(min_value=1, max_value=MAXIMUM_HEIGHT),
+    rate_constant=st.floats(min_value=MIN_RATE_PARAMETER, max_value=MAX_RATE_PARAMETER),
+    conservative=st.booleans(),
     min_area=st.floats(min_value=MINIMUM_AREA, max_value=MAXIMUM_AREA),
     max_area=st.floats(min_value=MINIMUM_AREA, max_value=MAXIMUM_AREA),
     min_conc=st.floats(min_value=MINIMUM_CONC, max_value=MAXIMUM_CONC),
@@ -199,6 +214,8 @@ def generate_r_ary_sample_network(
 def test_balanced_network(
     branching_factor: int,
     height: int,
+    rate_constant: float,
+    conservative: bool,  # Boolean that determines if the model is to be run conservatively or not
     min_area: float,
     max_area: float,
     min_conc: float,
@@ -215,12 +232,18 @@ def test_balanced_network(
 
     areas = lambda: draw_random_log_uniform(min_area, max_area)
     concentrations = lambda: draw_random_log_uniform(min_conc, max_conc)
+
     network = generate_balanced_sample_network(
         branching_factor=branching_factor, height=height, areas=areas
     )
     upstream = conc_list_to_dict(network, concentrations)
-    downstream = funmixer.forward_model(sample_network=network, upstream_concentrations=upstream)
-    problem = funmixer.SampleNetworkUnmixer(sample_network=network, use_regularization=False)
+    rate_constants = None if conservative else {node: rate_constant for node in network.nodes}
+    downstream = funmixer.forward_model(
+        sample_network=network, upstream_concentrations=upstream, rate_constants=rate_constants
+    )
+    problem = funmixer.SampleNetworkUnmixer(
+        sample_network=network, use_regularization=False, rate_constants=rate_constants
+    )
     solution = problem.solve(downstream)
 
     # Check that the recovered upstream concentrations are within 0.1% of the true upstream concentrations using
@@ -235,6 +258,8 @@ def test_balanced_network(
 @given(
     branching_factor=st.integers(min_value=1, max_value=MAXIMUM_BRANCHING_FACTOR),
     N=st.integers(min_value=2, max_value=MAXIMUM_NUMBER_OF_NODES),
+    rate_constant=st.floats(min_value=MIN_RATE_PARAMETER, max_value=MAX_RATE_PARAMETER),
+    conservative=st.booleans(),
     min_area=st.floats(min_value=MINIMUM_AREA, max_value=MAXIMUM_AREA),
     max_area=st.floats(min_value=MINIMUM_AREA, max_value=MAXIMUM_AREA),
     min_conc=st.floats(min_value=MINIMUM_CONC, max_value=MAXIMUM_CONC),
@@ -244,6 +269,8 @@ def test_balanced_network(
 def test_rary_network(
     branching_factor: int,
     N: int,
+    rate_constant: float,
+    conservative: bool,
     min_area: float,
     max_area: float,
     min_conc: float,
@@ -262,8 +289,13 @@ def test_rary_network(
     concentrations = lambda: draw_random_log_uniform(min_conc, max_conc)
     network = generate_r_ary_sample_network(N=N, branching_factor=branching_factor, areas=areas)
     upstream = conc_list_to_dict(network, concentrations)
-    downstream = funmixer.forward_model(sample_network=network, upstream_concentrations=upstream)
-    problem = funmixer.SampleNetworkUnmixer(sample_network=network, use_regularization=False)
+    rate_constants = None if conservative else {node: rate_constant for node in network.nodes}
+    downstream = funmixer.forward_model(
+        sample_network=network, upstream_concentrations=upstream, rate_constants=rate_constants
+    )
+    problem = funmixer.SampleNetworkUnmixer(
+        sample_network=network, use_regularization=False, rate_constants=rate_constants
+    )
     solution = problem.solve(downstream)
 
     # Check that the recovered upstream concentrations are within 0.1% of the true upstream concentrations using


### PR DESCRIPTION
This PR adds the ability for funmixer to simulate first order decay processes modifying tracer concentrations between sample sites on a drainage network. If we consider that the hydrographical (i.e., along flow-path) distance between two nodes on the sample network is $x$, and assuming that some tracer is removed as a function of distance according to: $\frac{dC}{dx} = -k$ then the contribution from the upstream node to the downstream node is best described by: $C_0 \exp(-kx)$, where $C_0$ is the contribution from the upstream node. 

This PR implements this by making the following changes:

- Extracting the hydrographical distance between nodes from the D8 raster and sample sites, and storing this as an edge `length` on the `networkx` sample network (see `d8_processing.py`, `flow_acc_cfuncs.pyx`)
- Modifying the primary terms of the optimisation (and forward model) to include an exponential decay term 
- Implementing this within the test functions which now solves random optimisation problems with and without conservative behaviour for (uniform) decay constants $0 < k < 3$.

To consider non-conservative processes, the user simply has to provide a dictionary mapping sample names onto a rate constant. These rate constants apply to the edge _downstream_ of that node. Different rate constants can be set across the entire study area. If `rate_constants` is not supplied, default values of $k=0$ are assumed, which recovers the initial non-conservative behaviour. 

## Notes  
- Because  $C_0 \exp(-kx)$ is not-affine with  respect to $k$, the optimisation problem cannot be made [DPP compliant](https://www.cvxpy.org/tutorial/dpp/index.html). As a result, unlike other parameters (e.g., export rates), the rate constants must be set when the problem is first built, and cannot be subsequently modified. $k$ for each node is therefore **not** a CVXPY parameter, rather a `float`
- The units of $k$ are reciprocal **distance** $[L]^{-1}$ where the length unit is inherited from that of the D8 raster. As a consequence, to convert rate constants which have units $[T]^{-1}$ (e.g., $\mathrm{s}^{-1}$), some estimate of the material velocity ($v$) must be used! 

# CoPilot Summary

This pull request introduces support for first-order (exponential decay) rate constants in the sample network unmixing workflow, enabling modeling of non-conservative tracer behavior along drainage networks. It also improves the handling of spatial information in the D8 flow direction raster, including accurate calculation of distances between nodes and sub-basin areas. The most important changes are grouped below:

**Support for First-Order Rate Constants in Network Unmixer:**

* Added a `my_rate_constant` attribute to the `SampleNode` class and corresponding handling in the `SampleNetworkUnmixer`, allowing each sub-basin/reach to have an associated decay rate constant. The rate constants are now used to weight tracer fluxes between nodes using the exponential decay law.
* Added a `_set_rate_constants` method to `SampleNetworkUnmixer` to initialize and manage rate constants for each site, with validation and support for user input. The constructor and `solve_montecarlo` now accept `rate_constants` as an argument.

**Improvements to D8 Raster Handling and Sample Graph Construction:**

* Modified the Cython backend (`flow_acc_cfuncs.pyx`) and Python interface to pass cell sizes (`dx`, `dy`) and the D8 flow direction array to the sample graph builder. This enables accurate calculation of distances between nodes and sub-basin areas in physical units. 
* Updated the sample graph construction to record the distance between each sample site and its downstream neighbor, storing this as `distance_downstream` and using it as edge metadata in the network. 
* Changed area calculations to use physical cell area (`dx * dy`) instead of pixel counts, and added validation to ensure the total upstream area matches expectations. 

**Documentation and Type Improvements:**

* Expanded the docstring for `SampleNode` to clarify all attributes, including new ones related to rate constants and distances. 
* Added the `RateConstantData` type alias for clarity.